### PR TITLE
Support query conditions

### DIFF
--- a/test/support/create_table.rb
+++ b/test/support/create_table.rb
@@ -15,23 +15,32 @@ module CreateTable
     now = Time.now
     50.times.map do |i|
       t = now - i * 3600
-      { logtime: t.to_i, d: t.strftime("%Y-%m-%d"), t: t.strftime("%Y-%m-%d %H:%M:%S") }
+      {
+        d: t.strftime("%Y-%m-%d"),
+        t: t.strftime("%Y-%m-%d %H:%M:%S"),
+        id: i,
+        uuid: i.to_s,
+      }
     end
   end
 
   def create_table
     connection.query(<<~SQL)
       CREATE TABLE IF NOT EXISTS #{schema}.#{table} (
-        logtime integer,
         d date,
-        t timestamp
+        t timestamp,
+        id integer,
+        uuid varchar(12)
       );
     SQL
   end
 
   def insert_data
     data.each do |row|
-      connection.query(%Q[INSERT INTO #{schema}.#{table} VALUES (#{row[:logtime]}, '#{row[:d]}', '#{row[:t]}')])
+      connection.query(%Q[
+        INSERT INTO #{schema}.#{table} VALUES
+        ('#{row[:d]}', '#{row[:t]}', #{row[:id]}, '#{row[:uuid]}')
+      ])
     end
     connection.query('commit')
   end


### PR DESCRIPTION
Value specification:
* A value looks like an integer string is treated as an integer.
* If you want to treat it as as string, surround with double quote or single quote.
* A value does not look like an integer is treated as a string.

Operator specification:
* Only equality is supported now

The resource is monitored as an independent resource.